### PR TITLE
Branched 404 caching

### DIFF
--- a/quick-cache-pro/includes/advanced-cache.tpl.php
+++ b/quick-cache-pro/includes/advanced-cache.tpl.php
@@ -25,6 +25,7 @@ namespace quick_cache // Root namespace.
 		if(!defined('QUICK_CACHE_ENABLE')) define('QUICK_CACHE_ENABLE', '%%QUICK_CACHE_ENABLE%%');
 		if(!defined('QUICK_CACHE_DEBUGGING_ENABLE')) define('QUICK_CACHE_DEBUGGING_ENABLE', '%%QUICK_CACHE_DEBUGGING_ENABLE%%');
 		if(!defined('QUICK_CACHE_ALLOW_BROWSER_CACHE')) define('QUICK_CACHE_ALLOW_BROWSER_CACHE', '%%QUICK_CACHE_ALLOW_BROWSER_CACHE%%');
+		if(!defined('QUICK_CACHE_CACHE_404_REQUESTS')) define('QUICK_CACHE_CACHE_404_REQUESTS', '%%QUICK_CACHE_CACHE_404_REQUESTS%%');
 
 		/*
 		 * Cache directory. Max age; e.g. `7 days` — anything compatible w/ `strtotime()`.
@@ -283,13 +284,8 @@ namespace quick_cache // Root namespace.
 					if(function_exists('zlib_get_coding_type') && zlib_get_coding_type() && (!($zlib_oc = ini_get('zlib.output_compression')) || !preg_match('/^(?:1|on|yes|true)$/i', $zlib_oc)))
 						throw new \exception(__('Unable to cache already-compressed output. Please use `mod_deflate` w/ Apache; or use `zlib.output_compression` in your `php.ini` file. Quick Cache is NOT compatible with `ob_gzhandler()` and others like this.', $this->text_domain));
 
-					/**
-					 * @TODO this needs to be an option in the UI, to cache 404s or exclude them. We might also want to allow for configuring the 404 cache filename (`----404----.html` by default).
-					 */
-					$_404s_allowed = TRUE;
 					$is_404        = FALSE;
-
-					if(function_exists('is_404') && ($is_404 = is_404()) && !$_404s_allowed)
+					if(function_exists('is_404') && ($is_404 = is_404()) && !QUICK_CACHE_CACHE_404_REQUESTS)
 						return $buffer;
 
 					if(function_exists('is_maintenance') && is_maintenance()) return $buffer; # http://wordpress.org/extend/plugins/maintenance-mode

--- a/quick-cache-pro/includes/menu-pages.php
+++ b/quick-cache-pro/includes/menu-pages.php
@@ -283,6 +283,26 @@ namespace quick_cache // Root namespace.
 					echo '<div class="plugin-menu-page-panel">'."\n";
 
 					echo '   <div class="plugin-menu-page-panel-heading">'."\n";
+					echo '      <i class="fa fa-gears"></i> '.__('404 Requests', plugin()->text_domain)."\n";
+					echo '   </div>'."\n";
+
+					echo '   <div class="plugin-menu-page-panel-body clearfix">'."\n";
+					echo '      <i class="fa fa-question-circle fa-4x" style="float:right; margin: 0 0 0 25px;"></i>'."\n";
+					echo '      <h3>'.__('Caching Enabled for 404 Requests?', plugin()->text_domain).'</h3>'."\n";
+					echo '      <p>'.__('When this is set to <code>No</code>, Quick Cache will ignore all 404 requests and no cache file will be served. While this is fine for most site owners, caching the 404 page on a high-traffic site may further reduce server load. When this is set to <code>Yes</code>, Quick Cache will cache the 404 page (see <a href="https://codex.wordpress.org/Creating_an_Error_404_Page" target="_blank">Creating an Error 404 Page</a>) and then serve that single cache file to all future 404 requests.', plugin()->text_domain).'</p>'."\n";
+					echo '      <p><select name="'.esc_attr(__NAMESPACE__).'[save_options][cache_404_requests]">'."\n";
+					echo '            <option value="0"'.selected(plugin()->options['cache_404_requests'], '0', FALSE).'>'.__('No, do NOT cache (or serve a cache file) for 404 requests.', plugin()->text_domain).'</option>'."\n";
+					echo '            <option value="1"'.selected(plugin()->options['cache_404_requests'], '1', FALSE).'>'.__('Yes, I would like to cache the 404 page and serve the cached file for 404 requests.', plugin()->text_domain).'</option>'."\n";
+					echo '         </select></p>'."\n";
+					echo '      <p class="info">'.__('<strong>How does Quick Cache cache 404 requests?</strong> Quick Cache will create a special cache file (<code>----404----.html</code>, see Advanced Tip below) for the first 404 request and then <a href="http://www.php.net/manual/en/function.symlink.php" target="_blank">symlink</a> future 404 requests to this special cache file. That way you don\'t end up with lots of 404 cache files that all contain the same thing (the contents of the 404 page). Instead, you\'ll have one 404 cache file and then several symlinks (i.e., references) to that 404 cache file.', plugin()->text_domain).'</p>'."\n";
+					echo '      <p class="info">'.__('<strong>Advanced Tip:</strong> The default 404 cache filename (<code>----404----.html</code>) is designed to minimize the chance of a collision with a cache file for a real page with the same name. However, if you want to override this default and define your own 404 cache filename, you can do so by adding <code>define(\'QUICK_CACHE_404_CACHE_FILENAME\', \'your-404-cache-filename\');</code> to your <code>wp-config.php</code> file (note that the <code>.html</code> extension should be excluded when defining a new filename).', plugin()->text_domain).'</p>'."\n";
+					echo '   </div>'."\n";
+
+					echo '</div>'."\n";
+
+					echo '<div class="plugin-menu-page-panel">'."\n";
+
+					echo '   <div class="plugin-menu-page-panel-heading">'."\n";
 					echo '      <i class="fa fa-gears"></i> '.__('RSS, RDF, and Atom Feeds', plugin()->text_domain)."\n";
 					echo '   </div>'."\n";
 

--- a/quick-cache-pro/quick-cache-pro.inc.php
+++ b/quick-cache-pro/quick-cache-pro.inc.php
@@ -57,6 +57,7 @@ namespace quick_cache // Root namespace.
 							                                'when_logged_in'                => '0', // `0|1|postload`.
 							                                'get_requests'                  => '0', // `0|1`.
 							                                'feeds_enable'                  => '0', // `0|1`.
+							                                'cache_404_requests'            => '0', // `0|1`.
 
 							                                'exclude_uris'                  => '', // Empty string or line-delimited patterns.
 							                                'exclude_refs'                  => '', // Empty string or line-delimited patterns.


### PR DESCRIPTION
@JasWSInc Could you please review this code for me? This Pull Request includes code for building the 404 cache file if it doesn't exist and then symlinking subsequent 404s to that 404 cache file.

I've tested this on my test installation and the 404 cache file generation and subsequent symlinking are working as expected. Clearing the cache also removes the symlinks as expected.

Also another note: I rewrote the section of code that checks the headers for cacheable headers (https://github.com/WebSharks/Quick-Cache-Pro/commit/ab681d0f32632f10de925bed1f3cebe2c3d888d2). Your method was to look for status codes or headers that _should not_ be cached and then return the buffer. My method allows only `HTTP 200` and `HTTP 404` status codes to be cached. 

I think this makes more sense and keeps things simple, but if there's another reason why you were specifically looking for certain headers (e.g., `Retry-After`), please let me know. I looked at WordPress Core and the only HTTP Status codes set by WordPress are `200`, `404`, `304`, and `500`. 
