### PR TITLE
Use http_response_code() to check HTTP status code, when available.

### DIFF
--- a/quick-cache-pro/includes/advanced-cache.tpl.php
+++ b/quick-cache-pro/includes/advanced-cache.tpl.php
@@ -1259,7 +1259,7 @@ namespace quick_cache
 			if(strpos($cache, '<body id="error-page">') !== FALSE)
 				return $this->maybe_add_nc_debug_info($buffer, $this::NC_DEBUG_WP_ERROR_PAGE);
 
-			if(!function_exists('http_response_code') && stripos($buffer, '<title>database error</title>'))
+			if(!function_exists('http_response_code') && stripos($cache, '<title>database error</title>') !== FALSE)
 				return $this->maybe_add_nc_debug_info($buffer, $this::NC_DEBUG_WP_ERROR_PAGE);
 
 			if(!$this->has_a_cacheable_content_type()) // Exclude non-HTML/XML content types.


### PR DESCRIPTION
Resolves WebSharks/quick-cache#175

@jaswsinc Quick code review, please?
