### PR TITLE
Fix buggy auto-purge comment routines

### DIFF
--- a/quick-cache-pro/quick-cache-pro.inc.php
+++ b/quick-cache-pro/quick-cache-pro.inc.php
@@ -1334,9 +1334,9 @@ namespace quick_cache
 					return $counter; // Already did this.
 				$this->cache[__FUNCTION__][$id][(integer)$force] = -1;
 
-				if(isset(static::$static['allow_purging']) && static::$static['allow_purging'] === FALSE)
+				if(isset(static::$static['___allow_auto_purge_post_cache']) && static::$static['___allow_auto_purge_post_cache'] === FALSE)
 				{
-					static::$static['allow_purging'] = TRUE; // Reset state.
+					static::$static['___allow_auto_purge_post_cache'] = TRUE; // Reset state.
 					return $counter; // Nothing to do.
 				}
 
@@ -1946,7 +1946,7 @@ namespace quick_cache
 
 				if($comment->comment_approved === 'spam' || $comment->comment_approved === '0')
 				{
-					static::$static['allow_purging'] = FALSE; // Don't allow next `auto_purge_post_cache()` call to clear post cache.
+					static::$static['___allow_auto_purge_post_cache'] = FALSE; // Don't allow next `auto_purge_post_cache()` call to clear post cache.
 					return $counter; // Don't allow spam to clear cache.
 				}
 
@@ -1994,7 +1994,7 @@ namespace quick_cache
 				}
 				else
 				{
-					static::$static['allow_purging'] = FALSE; // Don't allow next `auto_purge_post_cache()` call to clear post cache.
+					static::$static['___allow_auto_purge_post_cache'] = FALSE; // Don't allow next `auto_purge_post_cache()` call to clear post cache.
 					return $counter; // Don't allow Unapproved comments not being Approved to clear cache.
 				}
 


### PR DESCRIPTION
- Removed `edit_comment` and `delete_comment` action hooks from
  `auto_purge_comment_post_cache()`; these are now handled by the new
  `transition_comment_status` hook that is attached to the new
  `auto_purge_comment_transition()` routine.
- Added a new `auto_purge_comment_transition()` routine; this new
  routine properly handles the transition from one comment status to
  another and only calls the purge routine when necessary.
- A new `static::$static['allow_purging']` variable tracks when a
  comment status change should _not_ trigger a clear of the post cache
  and ensures that a subsequent call to `auto_purge_post_cache()` does
  not cause the post cache to be cleared. This is necessary because, for
  example, a spam comment will eventually trigger the `clear_post_cache`
  hook, which attaches directly to `auto_purge_post_cache()` and would
  result in the post cache being cleared even when the comment cache
  does not get cleared.

See websharks/quick-cache#159
