### PR TITLE
WP `redirect_canonical()` bug workaround. See websharks/quick-cache#209

### DIFF
--- a/quick-cache-pro/includes/advanced-cache.tpl.php
+++ b/quick-cache-pro/includes/advanced-cache.tpl.php
@@ -1182,12 +1182,20 @@ namespace quick_cache
 
 			if(!is_main_query()) return; // Not main query.
 
-			$this->is_wp_loaded_query   = TRUE;
-			$this->is_404               = is_404();
-			$this->is_user_logged_in    = is_user_logged_in();
-			$this->content_url          = rtrim(content_url(), '/');
-			$this->is_maintenance       = function_exists('is_maintenance') && is_maintenance();
-			$this->is_a_wp_content_type = $this->is_404 || $this->is_maintenance || is_front_page() || is_home() || is_singular() || is_archive() || is_post_type_archive() || is_tax() || is_search() || is_feed();
+			$this->is_wp_loaded_query = TRUE;
+			$this->is_404             = is_404();
+			$this->is_user_logged_in  = is_user_logged_in();
+			$this->content_url        = rtrim(content_url(), '/');
+			$this->is_maintenance     = function_exists('is_maintenance') && is_maintenance();
+
+			$_this = $this; // Reference for the closure below.
+			add_action('template_redirect', function () use ($_this)
+			{ // Move this AFTER `redirect_canonical` to avoid buggy WP behavior.
+				// See <https://github.com/websharks/quick-cache/issues/209#issuecomment-46999230>
+				$_this->is_a_wp_content_type = $_this->is_404 || $_this->is_maintenance
+				                               || is_front_page() // See <https://core.trac.wordpress.org/ticket/21602#comment:7>
+				                               || is_home() || is_singular() || is_archive() || is_post_type_archive() || is_tax() || is_search() || is_feed();
+			}, 11);
 		}
 
 		/**


### PR DESCRIPTION
Moves the `\quick_cache\advanced_cache::$is_a_wp_content_type` checks into `template_redirect` at priority `11`; which comes after the `redirect_canonical` hook fires. This is a good workaround for the bug reported in websharks/quick-cache#209 while we await a full solution from the WP dev team.

In short, we don't call upon `is_front_page()` until after `redirect_canonical()` has already done its thing. This doesn't correct the bug in WP, but it should keep Quick Cache from exposing it.
