### PR TITLE
Symlink 404 cache files atomically to avoid potential race condition.

### DIFF
--- a/quick-cache-pro/includes/advanced-cache.tpl.php
+++ b/quick-cache-pro/includes/advanced-cache.tpl.php
@@ -1284,10 +1284,10 @@ namespace quick_cache
 
 			# This is where a new 404 request might be detected for the first time; and where the 404 error file already exists in this case.
 
-			$cache_file_symlink_tmp = $this->cache_file.'.'.uniqid('', TRUE).'.tmp'; // Symlink creation is atomic; e.g. tmp file w/ rename.
+			$cache_file_tmp = $this->cache_file.'.'.uniqid('', TRUE).'.tmp'; // Cache/symlink creation is atomic; e.g. tmp file w/ rename.
 
 			if($this->is_404 && is_file($this->cache_file_404))
-				if(!(symlink($this->cache_file_404, $cache_file_symlink_tmp) && rename($cache_file_symlink_tmp, $this->cache_file_404)))
+				if(!(symlink($this->cache_file_404, $cache_file_tmp) && rename($cache_file_tmp, $this->cache_file)))
 					throw new \exception(sprintf(__('Unable to create symlink: `%1$s` » `%2$s`. Possible permissions issue (or race condition), please check your cache directory: `%3$s`.', $this->text_domain), $this->cache_file, $this->cache_file_404, QUICK_CACHE_DIR));
 				else return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_1ST_TIME_404_SYMLINK);
 
@@ -1304,8 +1304,6 @@ namespace quick_cache
 				$cache .= "\n".'<!-- '.htmlspecialchars(sprintf(__('This Quick Cache file will auto-expire (and be rebuilt) on: %1$s (based on your configured expiration time).', $this->text_domain), date('M jS, Y @ g:i a T', strtotime('+'.QUICK_CACHE_MAX_AGE)))).' -->';
 			}
 
-			$cache_file_tmp = $this->cache_file.'.'.uniqid('', TRUE).'.tmp'; // Cache creation is atomic; e.g. tmp file w/ rename.
-
 			/*
 			 * This is NOT a 404, or it is 404 and the 404 cache file doesn't yet exist (so we need to create it).
 			 */
@@ -1313,8 +1311,7 @@ namespace quick_cache
 			{
 				if(file_put_contents($cache_file_tmp, serialize($this->headers_list()).'<!--headers-->'.$cache) && rename($cache_file_tmp, $this->cache_file_404))
 				{
-					$cache_file_symlink_tmp = $this->cache_file.'.'.uniqid('', TRUE).'.tmp'; // Symlink creation is atomic; e.g. tmp file w/ rename.
-					if(!(symlink($this->cache_file_404, $cache_file_symlink_tmp) && rename($cache_file_symlink_tmp, $this->cache_file)))
+					if(!(symlink($this->cache_file_404, $cache_file_tmp) && rename($cache_file_tmp, $this->cache_file)))
 						throw new \exception(sprintf(__('Unable to create symlink: `%1$s` » `%2$s`. Possible permissions issue (or race condition), please check your cache directory: `%3$s`.', $this->text_domain), $this->cache_file, $this->cache_file_404, QUICK_CACHE_DIR));
 					else
 						return $cache; // Return the newly built cache; with possible debug information also.


### PR DESCRIPTION
See websharks/quick-cache#242
