### PR TITLE
Bug fix. `crons_setup` flag not being properly analyzed whenever a site ...

### DIFF
--- a/quick-cache-pro/quick-cache-pro.inc.php
+++ b/quick-cache-pro/quick-cache-pro.inc.php
@@ -354,7 +354,7 @@ namespace quick_cache
 					add_action('wp_print_footer_scripts', array($this, 'htmlc_footer_scripts'), PHP_INT_MAX);
 				}
 				add_filter('cron_schedules', array($this, 'extend_cron_schedules'));
-				if((integer)$this->options['crons_setup'] < 1398051975)
+				if(substr($this->options['crons_setup'], -4) !== '-pro' || (integer)$this->options['crons_setup'] < 1398051975)
 				{
 					wp_clear_scheduled_hook('_cron_'.__NAMESPACE__.'_auto_cache');
 					wp_schedule_event(time() + 60, 'every15m', '_cron_'.__NAMESPACE__.'_auto_cache');
@@ -362,7 +362,7 @@ namespace quick_cache
 					wp_clear_scheduled_hook('_cron_'.__NAMESPACE__.'_cleanup');
 					wp_schedule_event(time() + 60, 'daily', '_cron_'.__NAMESPACE__.'_cleanup');
 
-					$this->options['crons_setup'] = (string)time();
+					$this->options['crons_setup'] = time().'-pro'; // With `-pro` suffix.
 					update_option(__NAMESPACE__.'_options', $this->options); // Blog-specific.
 					if(is_multisite()) update_site_option(__NAMESPACE__.'_options', $this->options);
 				}


### PR DESCRIPTION
Bug fix. `crons_setup` flag not being properly analyzed whenever a site owner goes from LITE to the PRO version. See websharks/quick-cache#291
