### PR TITLE
Adding new methods `\quick_cache\share\cache_lock()` and `\quick_cache\s...

### DIFF
--- a/quick-cache-pro/includes/advanced-cache.tpl.php
+++ b/quick-cache-pro/includes/advanced-cache.tpl.php
@@ -1275,6 +1275,14 @@ namespace quick_cache
 			   && (!($zlib_oc = ini_get('zlib.output_compression')) || !filter_var($zlib_oc, FILTER_VALIDATE_BOOLEAN))
 			) return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_OB_ZLIB_CODING_TYPE);
 
+			# Lock the cache directory while writes take place here.
+
+			$cache_lock = $this->cache_lock(); // Lock cache directory.
+
+			# Construct a temp file for atomic cache writes.
+
+			$cache_file_tmp = $this->add_tmp_suffix($this->cache_file);
+
 			# Cache directory checks. The cache file directory is created here if necessary.
 
 			if(!is_dir(QUICK_CACHE_DIR) && mkdir(QUICK_CACHE_DIR, 0775, TRUE) && !is_file(QUICK_CACHE_DIR.'/.htaccess'))
@@ -1286,42 +1294,49 @@ namespace quick_cache
 
 			# This is where a new 404 request might be detected for the first time; and where the 404 error file already exists in this case.
 
-			$cache_file_tmp = $this->add_tmp_suffix($this->cache_file); // Cache/symlink creation is atomic; e.g. tmp file w/ rename.
-
 			if($this->is_404 && is_file($this->cache_file_404))
+			{
 				if(!(symlink($this->cache_file_404, $cache_file_tmp) && rename($cache_file_tmp, $this->cache_file)))
 					throw new \exception(sprintf(__('Unable to create symlink: `%1$s` » `%2$s`. Possible permissions issue (or race condition), please check your cache directory: `%3$s`.', $this->text_domain), $this->cache_file, $this->cache_file_404, QUICK_CACHE_DIR));
-				else return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_1ST_TIME_404_SYMLINK);
 
-			/* ------- Otherwise, we need to construct & store a new cache file. -------- */
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
+
+				return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_1ST_TIME_404_SYMLINK);
+			}
+			/* ------- Otherwise, we need to construct & store a new cache file. ----------------------------------------------- */
 
 			$cache = $this->maybe_compress_html($cache); // Possible HTML compression.
 
-			if(QUICK_CACHE_DEBUGGING_ENABLE && $this->is_html_xml_doc($cache)) // Only if HTML comments are possible.
+			if(QUICK_CACHE_DEBUGGING_ENABLE && $this->is_html_xml_doc($cache)) // Add HTML comments?
 			{
-				$total_time = number_format(microtime(TRUE) - $this->timer, 5, '.', '');
+				$total_time = number_format(microtime(TRUE) - $this->timer, 5, '.', ''); // Based on the original timer.
 				$cache .= "\n".'<!-- '.htmlspecialchars(sprintf(__('Quick Cache file path: %1$s', $this->text_domain), str_replace(WP_CONTENT_DIR, '', $this->is_404 ? $this->cache_file_404 : $this->cache_file))).' -->';
 				$cache .= "\n".'<!-- '.htmlspecialchars(sprintf(__('Quick Cache file built for (%1$s%2$s) in %3$s seconds, on: %4$s.', $this->text_domain),
 				                                                ($this->is_404) ? '404 [error document]' : $this->salt_location, (($this->user_token) ? '; '.sprintf(__('user token: %1$s', $this->text_domain), $this->user_token) : ''), $total_time, date('M jS, Y @ g:i a T'))).' -->';
 				$cache .= "\n".'<!-- '.htmlspecialchars(sprintf(__('This Quick Cache file will auto-expire (and be rebuilt) on: %1$s (based on your configured expiration time).', $this->text_domain), date('M jS, Y @ g:i a T', strtotime('+'.QUICK_CACHE_MAX_AGE)))).' -->';
 			}
-			/*
-			 * This is NOT a 404, or it is 404 and the 404 cache file doesn't yet exist (so we need to create it).
-			 */
+			# NOT a 404, or it is 404 and the 404 cache file doesn't yet exist (so we need to create it).
+
 			if($this->is_404) // This is a 404; let's create 404 cache file and symlink to it.
 			{
 				if(file_put_contents($cache_file_tmp, serialize($this->cacheable_headers_list()).'<!--headers-->'.$cache) && rename($cache_file_tmp, $this->cache_file_404))
 				{
 					if(!(symlink($this->cache_file_404, $cache_file_tmp) && rename($cache_file_tmp, $this->cache_file)))
 						throw new \exception(sprintf(__('Unable to create symlink: `%1$s` » `%2$s`. Possible permissions issue (or race condition), please check your cache directory: `%3$s`.', $this->text_domain), $this->cache_file, $this->cache_file_404, QUICK_CACHE_DIR));
-					else
-						return $cache; // Return the newly built cache; with possible debug information also.
-				}
-			} // NOT a 404; let's write a new cache file.
-			else if(file_put_contents($cache_file_tmp, serialize($this->cacheable_headers_list()).'<!--headers-->'.$cache) && rename($cache_file_tmp, $this->cache_file))
-				return $cache; // Return the newly built cache; with possible debug information also.
 
+					$this->cache_unlock($cache_lock); // Unlock cache directory.
+
+					return $cache; // Return the newly built cache; with possible debug information also.
+				}
+			} // NOT a 404; let's write a new cache file! This is where pages get cached. The cache is served back out on this first-time access.
+			else if(file_put_contents($cache_file_tmp, serialize($this->cacheable_headers_list()).'<!--headers-->'.$cache) && rename($cache_file_tmp, $this->cache_file))
+			{
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
+
+				return $cache; // Return the newly built cache; with possible debug information also.
+			}
 			@unlink($cache_file_tmp); // Clean this up (if it exists); and throw an exception with information for the site owner.
+
 			throw new \exception(sprintf(__('Quick Cache: failed to write cache file for: `%1$s`; possible permissions issue (or race condition), please check your cache directory: `%2$s`.', $this->text_domain), $_SERVER['REQUEST_URI'], QUICK_CACHE_DIR));
 		}
 

--- a/quick-cache-pro/includes/auto-cache.php
+++ b/quick-cache-pro/includes/auto-cache.php
@@ -148,6 +148,7 @@ namespace quick_cache // Root namespace.
 		protected function log_auto_cache_url($url, $wp_remote_get_response)
 		{
 			$cache_dir           = $this->plugin->cache_dir();
+			$cache_lock          = $this->plugin->cache_lock();
 			$auto_cache_log_file = $cache_dir.'/qc-auto-cache.log';
 
 			if(is_file($auto_cache_log_file) && !is_writable($auto_cache_log_file))
@@ -160,6 +161,8 @@ namespace quick_cache // Root namespace.
 			file_put_contents($auto_cache_log_file, $log_entry, FILE_APPEND);
 			if(filesize($auto_cache_log_file) > 2097152) // 2MB is the maximum log file size.
 				rename($auto_cache_log_file, substr($auto_cache_log_file, 0, -4).'-archived-'.time().'.log');
+
+			$this->plugin->cache_unlock($cache_lock); // Unlock cache directory.
 		}
 
 		/**
@@ -173,6 +176,7 @@ namespace quick_cache // Root namespace.
 		protected function log_auto_cache_run($total_urls, $total_time)
 		{
 			$cache_dir           = $this->plugin->cache_dir();
+			$cache_lock          = $this->plugin->cache_lock();
 			$auto_cache_log_file = $cache_dir.'/qc-auto-cache.log';
 
 			if(is_file($auto_cache_log_file) && !is_writable($auto_cache_log_file))
@@ -183,6 +187,8 @@ namespace quick_cache // Root namespace.
 			file_put_contents($auto_cache_log_file, $log_entry, FILE_APPEND);
 			if(filesize($auto_cache_log_file) > 2097152) // 2MB is the maximum log file size.
 				rename($auto_cache_log_file, substr($auto_cache_log_file, 0, -4).'-archived-'.time().'.log');
+
+			$this->plugin->cache_unlock($cache_lock); // Unlock cache directory.
 		}
 
 		/**

--- a/quick-cache-pro/includes/share.php
+++ b/quick-cache-pro/includes/share.php
@@ -1299,6 +1299,56 @@ namespace quick_cache // Root namespace.
 				return (string)rtrim($dir_file, DIRECTORY_SEPARATOR.'\\/').'-'.str_replace('.', '', uniqid('', TRUE)).'-tmp';
 			}
 
+			/**
+			 * Acquires system tmp directory path.
+			 *
+			 * @since 14xxxx Refactoring cache clear/purge routines.
+			 *
+			 * @return string System tmp directory path; else an empty string.
+			 */
+			public function get_tmp_dir()
+			{
+				if(isset(static::$static[__FUNCTION__]))
+					return static::$static[__FUNCTION__];
+
+				static::$static[__FUNCTION__] = ''; // Initialize.
+				$tmp_dir                      = &static::$static[__FUNCTION__];
+
+				if(defined('WP_TEMP_DIR'))
+					$possible_tmp_dirs[] = WP_TEMP_DIR;
+
+				if($this->function_is_possible('sys_get_temp_dir'))
+					$possible_tmp_dirs[] = sys_get_temp_dir();
+
+				if($this->function_is_possible('ini_get'))
+					$possible_tmp_dirs[] = ini_get('upload_tmp_dir');
+
+				if(!empty($_SERVER['TEMP']))
+					$possible_tmp_dirs[] = $_SERVER['TEMP'];
+
+				if(!empty($_SERVER['TMPDIR']))
+					$possible_tmp_dirs[] = $_SERVER['TMPDIR'];
+
+				if(!empty($_SERVER['TMP']))
+					$possible_tmp_dirs[] = $_SERVER['TMP'];
+
+				if(stripos(PHP_OS, 'win') === 0)
+					$possible_tmp_dirs[] = 'C:/Temp';
+
+				if(stripos(PHP_OS, 'win') !== 0)
+					$possible_tmp_dirs[] = '/tmp';
+
+				if(defined('WP_CONTENT_DIR'))
+					$possible_tmp_dirs[] = WP_CONTENT_DIR;
+
+				if(!empty($possible_tmp_dirs)) foreach($possible_tmp_dirs as $_tmp_dir)
+					if(($_tmp_dir = trim((string)$_tmp_dir)) && is_dir($_tmp_dir) && is_writable($_tmp_dir))
+						return ($tmp_dir = $this->n_dir_seps($_tmp_dir));
+				unset($_tmp_dir); // Housekeeping.
+
+				return ($tmp_dir = ''); // Failed to locate.
+			}
+
 			/* --------------------------------------------------------------------------------------
 			 * File/directory iteration utilities for Quick Cache.
 			 -------------------------------------------------------------------------------------- */
@@ -1438,6 +1488,10 @@ namespace quick_cache // Root namespace.
 				if($check_max_age && !($max_age = strtotime('-'.$this->options['cache_max_age'])))
 					return $counter; // Invalid cache expiration time.
 
+				/* ------- Begin lock state... ----------- */
+
+				$cache_lock = $this->cache_lock(); // Lock cache writes.
+
 				$cache_dir_tmp       = $this->add_tmp_suffix($cache_dir); // Temporary directory.
 				$cache_dir_tmp_regex = $regex; // Initialize host-specific regex pattern for the tmp directory.
 				$cache_dir_tmp_regex = '\\/'.ltrim($cache_dir_tmp_regex, '^\\/'); // Make sure it begins with an escaped `/`.
@@ -1479,6 +1533,10 @@ namespace quick_cache // Root namespace.
 
 				if(!rename($cache_dir_tmp, $cache_dir)) // Deletions are atomic; restore original directory now.
 					throw new \exception(sprintf(__('Unable to delete files. Rename failure on tmp directory: `%1$s`.', $this->text_domain), $cache_dir_tmp));
+
+				/* ------- End lock state... ------------- */
+
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
 
 				return $counter; // Total files deleted by this routine.
 			}
@@ -1533,6 +1591,10 @@ namespace quick_cache // Root namespace.
 
 				if($check_max_age && !($max_age = strtotime('-'.$this->options['cache_max_age'])))
 					return $counter; // Invalid cache expiration time.
+
+				/* ------- Begin lock state... ----------- */
+
+				$cache_lock = $this->cache_lock(); // Lock cache writes.
 
 				foreach(array('http', 'https') as $_host_scheme) // Consider `http|https` schemes.
 
@@ -1598,6 +1660,10 @@ namespace quick_cache // Root namespace.
 				unset($_host_scheme, $_host_url, $_host_cache_path_flags, $_host_cache_path,
 					$_host_cache_dir, $_host_cache_dir_tmp, $_host_cache_dir_tmp_regex); // Housekeeping.
 
+				/* ------- End lock state... ------------- */
+
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
+
 				return $counter; // Total files deleted by this routine.
 			}
 
@@ -1636,6 +1702,10 @@ namespace quick_cache // Root namespace.
 				if(preg_match('/^'.$wp_content_dir_regex.'\/(?:mu\-plugins|themes|plugins)(?:\/|$)/i', $dir))
 					return $counter; // Security flag; do nothing in this case.
 
+				/* ------- Begin lock state... ----------- */
+
+				$cache_lock = $this->cache_lock(); // Lock cache writes.
+
 				if(!rename($dir, $dir_temp)) // Work from tmp directory so deletions are atomic.
 					throw new \exception(sprintf(__('Unable to delete all files/dirs. Rename failure on tmp directory: `%1$s`.', $this->text_domain), $dir));
 
@@ -1666,7 +1736,76 @@ namespace quick_cache // Root namespace.
 						throw new \exception(sprintf(__('Unable to delete directory: `%1$s`.', $this->text_domain), $dir));
 					$counter++; // Increment counter for each directory we delete.
 				}
+				/* ------- End lock state... ------------- */
+
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
+
 				return $counter; // Total files deleted by this routine.
+			}
+
+			/* --------------------------------------------------------------------------------------
+			 * Cache locking utilities.
+			 -------------------------------------------------------------------------------------- */
+
+			/**
+			 * Get an exclusive lock on the cache directory.
+			 *
+			 * @since 140422 First documented version.
+			 *
+			 * @return array Lock type & resource handle needed to unlock later.
+			 *
+			 * @throws \exception If {@link \sem_get()} not available and there's
+			 *    no writable tmp directory for {@link \flock()} either.
+			 *
+			 * @throws \exception If unable to obtain an exclusive lock by any available means.
+			 *
+			 * @note This call is blocking; i.e. it will not return a lock until a lock becomes possible.
+			 *    In short, this will block the caller until such time as write access becomes possible.
+			 */
+			public function cache_lock()
+			{
+				if($this->function_is_possible('sem_get'))
+					if(($resource = sem_get(1976, 1)) && sem_acquire($resource))
+						return array('type' => 'sem', 'resource' => $resource);
+
+				// Use `flock()` as a decent fallback when `sem_get()` is not possible.
+
+				if(!($tmp_dir = $this->get_tmp_dir()))
+					throw new \exception(__('No writable tmp directory.', $this->text_domain));
+
+				$mutex = $tmp_dir.'/'.$this->slug.'.lock';
+				if(!($resource = fopen($mutex, 'w')) || !flock($resource, LOCK_EX))
+					throw new \exception(__('Unable to obtain an exclusive lock.', $this->text_domain));
+
+				return array('type' => 'flock', 'resource' => $resource);
+			}
+
+			/**
+			 * Release an exclusive lock on the cache directory.
+			 *
+			 * @since 140422 First documented version.
+			 *
+			 * @param array $lock Type & resource that we are unlocking.
+			 */
+			public function cache_unlock(array $lock)
+			{
+				if(!is_array($lock))
+					return; // Not possible.
+
+				if(empty($lock['type']) || empty($lock['resource']))
+					return; // Not possible.
+
+				if(!is_resource($lock['resource']))
+					return; // Not possible.
+
+				if($lock['type'] === 'sem')
+					sem_release($lock['resource']);
+
+				else if($lock['type'] === 'flock')
+				{
+					flock($lock['resource'], LOCK_UN);
+					fclose($lock['resource']);
+				}
 			}
 
 			/* --------------------------------------------------------------------------------------

--- a/quick-cache-pro/quick-cache-pro.inc.php
+++ b/quick-cache-pro/quick-cache-pro.inc.php
@@ -2763,7 +2763,7 @@ namespace quick_cache
 				if(!$this->remove_advanced_cache())
 					return FALSE; // Still exists.
 
-				$cache_dir               = $this->cache_dir(); // Current cache directory.
+				$cache_dir               = $this->cache_dir();
 				$advanced_cache_file     = WP_CONTENT_DIR.'/advanced-cache.php';
 				$advanced_cache_template = dirname(__FILE__).'/includes/advanced-cache.tpl.php';
 
@@ -2850,19 +2850,21 @@ namespace quick_cache
 				if(!file_put_contents($advanced_cache_file, $advanced_cache_contents))
 					return FALSE; // Failure; could not write file.
 
-				if(!is_dir($cache_dir))
-					mkdir($cache_dir, 0775, TRUE);
+				$cache_lock = $this->cache_lock(); // Lock cache.
+
+				if(!is_dir($cache_dir)) mkdir($cache_dir, 0775, TRUE);
 
 				if(is_writable($cache_dir) && !is_file($cache_dir.'/.htaccess'))
 					file_put_contents($cache_dir.'/.htaccess', $this->htaccess_deny);
 
-				if(!is_file($cache_dir.'/.htaccess'))
-					return NULL; // Failure; could not write .htaccess file. Special return value (NULL) in this case.
+				if(!is_dir($cache_dir) || !is_writable($cache_dir) || !is_file($cache_dir.'/.htaccess') || !file_put_contents($cache_dir.'/qc-advanced-cache', time()))
+				{
+					$this->cache_unlock($cache_lock); // Unlock cache.
+					return NULL; // Special return value (NULL) in this case.
+				}
+				$this->cache_unlock($cache_lock); // Unlock cache.
 
-				if(!is_dir($cache_dir) || !is_writable($cache_dir) || !file_put_contents($cache_dir.'/qc-advanced-cache', time()))
-					return NULL; // Failure; could not write cache entry. Special return value (NULL) in this case.
-
-				return TRUE; // All done :-)
+				return TRUE; // Success!
 			}
 
 			/**
@@ -2990,10 +2992,10 @@ namespace quick_cache
 
 				if(!is_multisite()) return $value; // N/A.
 
-				$cache_dir = $this->cache_dir(); // Cache dir.
+				$cache_dir  = $this->cache_dir(); // Cache dir.
+				$cache_lock = $this->cache_lock(); // Lock.
 
-				if(!is_dir($cache_dir))
-					mkdir($cache_dir, 0775, TRUE);
+				if(!is_dir($cache_dir)) mkdir($cache_dir, 0775, TRUE);
 
 				if(is_writable($cache_dir) && !is_file($cache_dir.'/.htaccess'))
 					file_put_contents($cache_dir.'/.htaccess', $this->htaccess_deny);
@@ -3009,6 +3011,8 @@ namespace quick_cache
 
 					file_put_contents($cache_dir.'/qc-blog-paths', serialize($paths));
 				}
+				$this->cache_unlock($cache_lock); // Unlock cache directory.
+
 				return $value; // Pass through untouched (always).
 			}
 


### PR DESCRIPTION
Ditto from lite pull request for Quick Cache...

> Adding new methods `\quick_cache\share\cache_lock()` and `\quick_cache\share\cache_unlock()`. These take of advantage of semaphores for file locking (if possible) with a fallback on `flock()` when `sem_get()` is not possible or fails. These methods are blocking, making it so that cache writes (including clearing, purging, wiping) all gain an exclusive lock on the cache directory while work is underway. This prevents issues like we have seen on very busy sites, reported in: websharks/quick-cache#288
