### PR TITLE
Bug Fix - Updating plugin via WP-CLI yields ZenCache Pro Errors,

### DIFF
--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -403,7 +403,7 @@ class Plugin extends AbsBaseAp
         /*[/pro]*/
         /* -------------------------------------------------------------- */
 
-        if (!$this->enable_hooks) {
+        if (!$this->enable_hooks || strcasecmp(PHP_SAPI, 'cli') === 0) {
             return; // Stop here; setup without hooks.
         }
         /* -------------------------------------------------------------- */


### PR DESCRIPTION
 See: websharks/zencache#563