### PR TITLE
Clear cache for specific URL; See: websharks/zencache#590

### DIFF
--- a/src/includes/classes/ApiBase.php
+++ b/src/includes/classes/ApiBase.php
@@ -88,6 +88,21 @@ class ApiBase
         return $GLOBALS[GLOBAL_NS]->autoClearPostCache($post_id);
     }
 
+    /**
+     * This clears the cache for a specific URL.
+     *
+     * @since 15xxxx Adding support for custom URLs.
+     *
+     * @param string $url Input URL to clear.
+     *
+     * @return int Total files cleared (if any).
+     */
+    public static function clearUrl($url)
+    {
+        $regex = $GLOBALS[GLOBAL_NS]->buildHostCachePathRegex($url);
+        return $GLOBALS[GLOBAL_NS]->clearFilesFromHostCacheDir($regex);
+    }
+
     /*[pro strip-from="lite"]*/
     /**
      * This erases the cache for a specific user ID.


### PR DESCRIPTION
Clear cache for specific URL; 
- Add new API Function that would allow a site owner to clear the cache for a specific URL
- Add `zencache::clearUrl($url);`

See: websharks/zencache#590