### PR TITLE
Add plugin activation message; See: websharks/zencache#112

### DIFF
--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -253,7 +253,7 @@ class Plugin extends AbsBaseAp
 
             'version'     => VERSION,
             'crons_setup' => '0', // `0` or timestamp.
-            'welcomed' => '0', // `0|1` welcomed yet?
+            'welcomed'    => '0', // `0|1` welcomed yet?
 
             /* Primary switch; enable? */
 

--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -253,6 +253,7 @@ class Plugin extends AbsBaseAp
 
             'version'     => VERSION,
             'crons_setup' => '0', // `0` or timestamp.
+            'welcomed' => '0', // `0|1` welcomed yet?
 
             /* Primary switch; enable? */
 

--- a/src/includes/closures/Plugin/InstallUtils.php
+++ b/src/includes/closures/Plugin/InstallUtils.php
@@ -12,7 +12,7 @@ $self->activate = function () use ($self) {
     $self->setup(); // Ensure setup is complete.
     if (!$self->options['welcomed']) {
         $settings_url = add_query_arg(urlencode_deep(array('page' => GLOBAL_NS)), network_admin_url('/admin.php'));
-        $self->enqueueMainNotice(sprintf(__('<strong>%1$s</strong> successfully installed! :-) Please <a href="%2$s">enable page caching</a> and configure options.', SLUG_TD), esc_html(NAME), esc_attr($settings_url), array('push_to_top' => true)));
+        $self->enqueueMainNotice(sprintf(__('<strong>%1$s</strong> successfully installed! :-) Please <a href="%2$s">enable caching and review options</a>.', SLUG_TD), esc_html(NAME), esc_attr($settings_url), array('push_to_top' => true)));
         $self->updateOptions(array('welcomed' => '1'));
     }
     if (!$self->options['enable']) {

--- a/src/includes/closures/Plugin/InstallUtils.php
+++ b/src/includes/closures/Plugin/InstallUtils.php
@@ -10,13 +10,11 @@ namespace WebSharks\ZenCache\Pro;
  */
 $self->activate = function () use ($self) {
     $self->setup(); // Ensure setup is complete.
-
     if (!$self->options['welcomed']) {
-        $settings_url = add_query_arg(urlencode_deep(array('page' => GLOBAL_NS)), network_admin_url('/admin.php')));
-        $self->enqueueMainNotice(sprintf(__('<strong>%1$s</strong> successfully installed! :-) Please <a href="%2$s">enable page caching</a> and configure options.', SLUG_TD), esc_html(NAME), esc_attr($settings_url), array('push_to_top' => true));
+        $settings_url = add_query_arg(urlencode_deep(array('page' => GLOBAL_NS)), network_admin_url('/admin.php'));
+        $self->enqueueMainNotice(sprintf(__('<strong>%1$s</strong> successfully installed! :-) Please <a href="%2$s">enable page caching</a> and configure options.', SLUG_TD), esc_html(NAME), esc_attr($settings_url), array('push_to_top' => true)));
         $self->updateOptions(array('welcomed' => '1'));
     }
-
     if (!$self->options['enable']) {
         return; // Nothing to do.
     }

--- a/src/includes/closures/Plugin/InstallUtils.php
+++ b/src/includes/closures/Plugin/InstallUtils.php
@@ -11,6 +11,12 @@ namespace WebSharks\ZenCache\Pro;
 $self->activate = function () use ($self) {
     $self->setup(); // Ensure setup is complete.
 
+    if (!$self->options['welcomed']) {
+        $settings_url = add_query_arg(urlencode_deep(array('page' => GLOBAL_NS)), network_admin_url('/admin.php')));
+        $self->enqueueMainNotice(sprintf(__('<strong>%1$s</strong> successfully installed! :-) Please <a href="%2$s">enable page caching</a> and configure options.', SLUG_TD), esc_html(NAME), esc_attr($settings_url), array('push_to_top' => true));
+        $self->updateOptions(array('welcomed' => '1'));
+    }
+
     if (!$self->options['enable']) {
         return; // Nothing to do.
     }


### PR DESCRIPTION
Add plugin activation message; 

- Add plugin activation message that directs users to the settings page to configure/enable ZenCache after activation.

![ZenCache Plugin activation message](https://cloud.githubusercontent.com/assets/7514953/11197509/e973cfca-8cf8-11e5-803e-797de9d32e81.png)


See: websharks/zencache#112