### PR TITLE
Fix bug where Permalinks ending with htm/html were not excluded from CDN

### DIFF
--- a/src/includes/classes/CdnFilters.php
+++ b/src/includes/classes/CdnFilters.php
@@ -545,7 +545,7 @@ class CdnFilters extends AbsBase
     public static function defaultWhitelistedExtensions()
     {
         $extensions = array_keys(wp_get_mime_types());
-        $extensions = array_map('strtolower', $extensions);
+        $extensions = explode('|', strtolower(implode('|', $extensions)));
         $extensions = array_merge($extensions, array('eot', 'ttf', 'otf', 'woff'));
 
         if (($permalink_structure = get_option('permalink_structure'))) {


### PR DESCRIPTION
See https://github.com/websharks/zencache/issues/495#issuecomment-160324313