### PR TITLE
Replace `update_user_metadata` with `updated_user_meta`; See: websharks/zencache#623

### DIFF
--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -506,7 +506,7 @@ class Plugin extends AbsBaseAp
         /*[pro strip-from="lite"]*/
         add_action('profile_update', array($this, 'autoClearUserCacheA1'));
         add_filter('add_user_metadata', array($this, 'autoClearUserCacheFA2'), 10, 2);
-        add_filter('update_user_metadata', array($this, 'autoClearUserCacheFA2'), 10, 2);
+        add_action('updated_user_meta', array($this, 'autoClearUserCacheA2'), 10, 2);
         add_filter('delete_user_metadata', array($this, 'autoClearUserCacheFA2'), 10, 2);
         add_action('set_auth_cookie', array($this, 'autoClearUserCacheA4'), 10, 4);
         add_action('clear_auth_cookie', array($this, 'autoClearUserCacheCur'));

--- a/src/includes/closures/Plugin/WcpUserUtils.php
+++ b/src/includes/closures/Plugin/WcpUserUtils.php
@@ -9,7 +9,7 @@ namespace WebSharks\ZenCache\Pro;
  *
  * @attaches-to `profile_update` hook.
  * @attaches-to `add_user_metadata` filter.
- * @attaches-to `update_user_metadata` filter.
+ * @attaches-to `updated_user_meta` hook.
  * @attaches-to `delete_user_metadata` filter.
  * @attaches-to `set_auth_cookie` hook.
  * @attaches-to `clear_auth_cookie` hook.
@@ -60,12 +60,26 @@ $self->autoClearUserCacheA1 = function ($user_id) use ($self) {
 };
 
 /*
+* Automatically clears cache files associated with a particular user.
+*
+* @since 150422 Rewrite.
+*
+* @attaches-to `updated_user_meta` hook.
+*
+* @param int    $meta_id    ID of updated metadata entry.
+* @param int    $object_id  Object ID.
+*/
+$self->autoClearUserCacheA2 = function ($meta_id, $object_id) use ($self) {
+    $self->autoClearUserCache($object_id);
+};
+
+/*
  * Automatically clears cache files associated with a particular user.
  *
  * @since 150422 Rewrite.
  *
  * @attaches-to `add_user_metadata` filter.
- * @attaches-to `update_user_metadata` filter.
+ * @attaches-to `updated_user_meta` hook.
  * @attaches-to `delete_user_metadata` filter.
  *
  * @param mixed $value   Filter value (passes through).

--- a/src/includes/closures/Plugin/WcpUserUtils.php
+++ b/src/includes/closures/Plugin/WcpUserUtils.php
@@ -62,7 +62,7 @@ $self->autoClearUserCacheA1 = function ($user_id) use ($self) {
 /*
 * Automatically clears cache files associated with a particular user.
 *
-* @since 150422 Rewrite.
+* @since 15xxxx Using `updated_user_meta` instead of `update_user_metadata`
 *
 * @attaches-to `updated_user_meta` hook.
 *


### PR DESCRIPTION
Replace `update_user_metadata` with `updated_user_meta`; 

- Use `updated_user_meta` hook instead of `update_user_metadata` filter
- Create new `autoClearUserCacheA2()` method 

See: websharks/zencache#623