### PR TITLE
Only add/remove from htaccess file when necessary

### DIFF
--- a/src/includes/closures/Plugin/HtaccessUtils.php
+++ b/src/includes/closures/Plugin/HtaccessUtils.php
@@ -24,7 +24,7 @@ $self->addWpHtaccess = function () use ($self) {
         return false; // Not running the Apache web server.
     }
     if (!$self->options['enable']) {
-        return false; // Nothing to do.
+        return true; // Nothing to do.
     }
     if (!$self->removeWpHtaccess()) {
         return false; // Unable to remove.

--- a/src/includes/closures/Plugin/HtaccessUtils.php
+++ b/src/includes/closures/Plugin/HtaccessUtils.php
@@ -11,6 +11,15 @@ namespace WebSharks\ZenCache\Pro;
 $self->htaccess_marker = 'WmVuQ2FjaGU';
 
 /*
+* Plugin options that have associated htaccess rules.
+*
+* @since 15xxxx Improving `.htaccess` tweaks.
+*
+* @return array Plugin options that have associated htaccess rules
+*/
+$self->options_with_htaccess_rules = array('cdn_enable');
+
+/*
  * Add template blocks to `/.htaccess` file.
  *
  * @since 151114 Adding `.htaccess` tweaks.
@@ -25,6 +34,12 @@ $self->addWpHtaccess = function () use ($self) {
     }
     if (!$self->options['enable']) {
         return true; // Nothing to do.
+    }
+    if (!$self->needHtaccessRules()) {
+        if($self->findHtaccessMarker()) { // Do we need to clean up previously added rules?
+            $self->removeWpHtaccess(); // Fail silently since we don't need rules in place.
+        }
+        return true; // Nothing to do; no options enabled that require htaccess rules.
     }
     if (!$self->removeWpHtaccess()) {
         return false; // Unable to remove.
@@ -114,6 +129,25 @@ $self->findHtaccessFile = function () use ($self) {
         $file = $htaccess_file;
     }
     return $file;
+};
+
+/*
+ * Determines if there are any plugin options enabled that require htaccess rules to be added.
+ *
+ * @since 15xxxx Improving `.htaccess` tweaks.
+ *
+ * @return bool True when an option is enabled that requires htaccess rules, false otherwise.
+ */
+$self->needHtaccessRules = function () use ($self) {
+    if(!is_array($self->options_with_htaccess_rules)) {
+        return false; // Nothing to do.
+    }
+    foreach ($self->options_with_htaccess_rules as $option) {
+        if ($self->options[$option]) {
+            return true; // Yes, there are options enabled that require htaccess rules.
+        }
+    }
+    return false; // No, there are no options enabled that require htaccess rules.
 };
 
 /*


### PR DESCRIPTION
See websharks/zencache#641

---
_Quoting @raamdev from https://github.com/websharks/zencache/issues/641#issuecomment-167659466:_

> After some research, I discovered a few issues with the htaccess utilities in ZenCache Pro v151220:
> 
> - Every time the plugin options are saved when ZenCache is enabled, ZenCache [calls `addWpHtaccess()`](https://github.com/websharks/zencache-pro/blob/151220/src/includes/classes/Actions.php#L570-L572), regardless of whether or not it actually needs to (i.e., whether or not any options are enabled that require adding something to the htaccess file).
> - ZenCache does not intelligently keep track of which options are currently enabled that require htaccess rules, and as a result [more code than necessary](https://github.com/websharks/zencache-pro/blob/151220/src/includes/closures/Plugin/HtaccessUtils.php#L21-L42) is being run each time the site owner saves the plugin options and `addWpHtaccess()` is called.
> 
> As a result of all this unnecessary work, I believe we're increasing the chances that the site owner might see an error message when the error message isn't even applicable (i.e., ZenCache has no reason to add/remove anything from the htaccess file).
> 
> I've submitted a PR (https://github.com/websharks/zencache-pro/issues/204) that resolves these issues.
