### PR TITLE
Show Dashboard notice when ACE is enabled and PHP allow_url_fopen=0

### DIFF
--- a/src/includes/classes/Actions.php
+++ b/src/includes/classes/Actions.php
@@ -576,6 +576,9 @@ class Actions extends AbsBase
             if (!($add_advanced_cache = $this->plugin->addAdvancedCache())) {
                 $query_args[GLOBAL_NS.'_advanced_cache_add_failure'] = $add_advanced_cache === null ? 'advanced-cache' : '1';
             }
+            if (!$this->plugin->options['auto_cache_enable']) {
+                $this->plugin->autoCacheMaybeClearPhpIniError(true);
+            }
             if (!$this->plugin->options['auto_cache_enable'] || !$this->plugin->options['auto_cache_sitemap_url']) {
                 $this->plugin->autoCacheMaybeClearPrimaryXmlSitemapError(true);
             }
@@ -591,6 +594,7 @@ class Actions extends AbsBase
                 $query_args[GLOBAL_NS.'_advanced_cache_remove_failure'] = '1';
             }
             $this->plugin->autoCacheMaybeClearPrimaryXmlSitemapError(true);
+            $this->plugin->autoCacheMaybeClearPhpIniError(true);
         }
         $redirect_to = add_query_arg(urlencode_deep($query_args), $redirect_to);
 

--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -440,6 +440,7 @@ class Plugin extends AbsBaseAp
 
         /*[pro strip-from="lite"]*/
         add_action('admin_init', array($this, 'autoCacheMaybeClearPrimaryXmlSitemapError'));
+        add_action('admin_init', array($this, 'autoCacheMaybeClearPhpIniError'));
         add_action('admin_init', array($this, 'statsLogPinger'));
         /*[/pro]*/
 

--- a/src/includes/closures/Plugin/AutoCacheUtils.php
+++ b/src/includes/closures/Plugin/AutoCacheUtils.php
@@ -21,6 +21,9 @@ $self->autoCache = function () use ($self) {
             return; // Nothing to do.
         }
     }
+    if (!$self->autoCacheCheckPhpIni()) {
+        return; // Server does not meet minimum requirements.
+    }
     new AutoCache();
 };
 

--- a/src/includes/closures/Plugin/AutoCacheUtils.php
+++ b/src/includes/closures/Plugin/AutoCacheUtils.php
@@ -25,6 +25,54 @@ $self->autoCache = function () use ($self) {
 };
 
 /**
+ * Check if PHP configuration meets minimum requirements for Auto-Cache Engine and remove old notice if necessary.
+ *
+ * @since 15xxxx Improving Auto-Cache Engine minimum PHP requirements reporting.
+ *
+ * @param bool $force Defaults to a FALSE value.
+ *
+ * @attaches-to `admin_init`
+ *
+ * @note This routine is also called from `saveOptions()`.
+ */
+$self->autoCacheMaybeClearPhpIniError = function ($force = false) use ($self) {
+    if ($force) {
+        $self->dismissMainNotice('allow_url_fopen_disabled');
+        return; // Nothing else to do.
+    }
+    if (!$self->options['enable']) {
+        return; // Nothing to do.
+    }
+    if (!$self->options['auto_cache_enable']) {
+        return; // Nothing to do.
+    }
+    $self->autoCacheCheckPhpIni();
+};
+
+/**
+ * Check if PHP configuration meets minimum requirements for Auto-Cache Engine and display a notice if necessary.
+ *
+ * @since 15xxxx Improving Auto-Cache Engine minimum PHP requirements reporting.
+ *
+ * @return bool `TRUE` if all required PHP configuration is present, else `FALSE`. This also creates a dashboard notice in some cases.
+ *
+ * @note  Unlike `autoCacheCheckXmlSitemap()`, this routine is NOT used by the Auto-Cache Engine class when the Auto-Cache Engine is running.
+ */
+$self->autoCacheCheckPhpIni = function () use ($self) {
+    if (!filter_var(ini_get('allow_url_fopen'), FILTER_VALIDATE_BOOLEAN)) { // Is allow_url_fopen=1?
+        $self->dismissMainNotice('allow_url_fopen_disabled'); // Clear any previous allow_url_fopen notice.
+        $self->enqueueMainNotice(
+          sprintf(__('<strong>%1$s says...</strong> The Auto-Cache Engine requires <a href="http://zencache.com/r/allow_url_fopen/" target="_blank">PHP URL-aware fopen wrappers</a> (<code>allow_url_fopen=1</code>), however this option has been disabled by your <code>php.ini</code> runtime configuration. Please contact your web hosting company to resolve this issue or disable the Auto-Cache Engine in the <a href="'.esc_attr(add_query_arg(urlencode_deep(array('page' => GLOBAL_NS)), self_admin_url('/admin.php'))).'">settings</a>.', SLUG_TD), esc_html(NAME)),
+          array('class' => 'error', 'persistent_key' => 'allow_url_fopen_disabled', 'dismissable' => false)
+        );
+        return false; // Nothing more we can do in this case.
+    }
+    $self->dismissMainNotice('allow_url_fopen_disabled'); // Any previous problems have been fixed; dismiss any existing failure notice
+
+    return true;
+};
+
+/**
  * Check if Auto-Cache Engine XML Sitemap is valid and remove old notice if necessary.
  *
  * @since 151220 Improving XML Sitemap error checking.

--- a/src/includes/closures/Plugin/NoticeUtils.php
+++ b/src/includes/closures/Plugin/NoticeUtils.php
@@ -290,5 +290,7 @@ $self->normalizeNotice = function (array $notice, array $args = array()) use ($s
     } // ↑ Typecast each of the array elements.
     unset($_key, $_value); // A little housekeeping.
 
+    ksort($notice); // For more accurate comparison in other routines.
+
     return $notice; // Normalized.
 };


### PR DESCRIPTION
See websharks/zencache#644

---

**Note:** This PR also prevents the Auto-Cache Engine from running when `allow_url_fopen=0`; see https://github.com/websharks/zencache-pro/commit/461435154569927b1b78de9a717b67c4c9bc4715