### PR TITLE
Update Stat Log Endpoint URL; See: websharks/zencache#661

### DIFF
--- a/src/includes/closures/Plugin/StatsUtils.php
+++ b/src/includes/closures/Plugin/StatsUtils.php
@@ -21,7 +21,7 @@ $self->statsLogPinger = function () use ($self) {
     $self->updateOptions(array('last_pro_stats_log' => time()));
 
     $wpdb               = $self->wpdb(); // WordPress DB.
-    $stats_api_url      = 'https://www.websharks-inc.com/products/stats-log.php';
+    $stats_api_url      = 'https://stats.wpsharks.io/log';
     $stats_api_url_args = array( // See: <https://zencache.com/?p=1458>
         'os'              => PHP_OS,
         'php_version'     => PHP_VERSION,


### PR DESCRIPTION
Update Stat Log Endpoint URL; 

- Endpoint URL updated to `https://stats.wpsharks.io/log`

See: websharks/zencache#661