### PR TITLE
Bug Fix: Notice: id was called incorrectly. Product properties should…

### DIFF
--- a/src/includes/traits/Plugin/WcpWooCommerceUtils.php
+++ b/src/includes/traits/Plugin/WcpWooCommerceUtils.php
@@ -24,7 +24,7 @@ trait WcpWooCommerceUtils
         $done = true; // Flag as having been done.
 
         if (class_exists('\\WooCommerce')) {
-            $counter += $this->autoClearPostCache($product->id);
+            $counter += $this->autoClearPostCache($product->get_id());
         }
     }
 


### PR DESCRIPTION
This fixes a PHP notice error when going through a checkout on Woocommerce. Since version 3.0 product properties should not be accessed directly. Instead we must use get_id() or get_data() etc...