### PR TITLE
Remove invalid "require-lite" property from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,6 @@
     "browscap/browscap-php": "3.0.0",
     "ramsey/uuid": "3.*"
   },
-  "require-lite": {
-    "php": ">=5.4",
-    "websharks/sharkicons": "160221",
-    "websharks/wp-php-rv": "160824.6416"
-  },
   "require-dev": {
     "package/bourbon": "4.2.3",
     "websharks/wp-i18n-tools": "dev-master"


### PR DESCRIPTION
It's currently impossible to mirror the package in packagist.com. Although the service won't show me any logs, I suspect that the invalid `require-lite` property is the root cause.

Running `composer validate`:
```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
The property require-lite is not defined and the definition does not allow additional properties
License "GPL-3.0+" is a deprecated SPDX license identifier, use "GPL-3.0-or-later" instead
require.websharks/sharkicons : exact version constraints (160221) should be avoided if the package follows semantic versioning
require.websharks/wp-php-rv : exact version constraints (160824.6416) should be avoided if the package follows semantic versioning
require.websharks/html-compressor : exact version constraints (170420.24924) should be avoided if the package follows semantic versioning
require.thadafinser/user-agent-parser : exact version constraints (1.5.0) should be avoided if the package follows semantic versioning
require.browscap/browscap-php : exact version constraints (3.0.0) should be avoided if the package follows semantic versioning
```

This PR removes the property completely.
CC @raamdev, @jaswrks.

_You should probably also update the `license` property._